### PR TITLE
Update Sim_EX1_178.cs

### DIFF
--- a/cards/Sim_EX1_178.cs
+++ b/cards/Sim_EX1_178.cs
@@ -10,11 +10,12 @@ namespace HREngine.Bots
         //    wählt aus:/ +5 angriff; oder +5 leben und spott/.
         public override void getBattlecryEffect(Playfield p, Minion own, Minion target, int choice)
         {
-            if (choice == 2)
+            //These seem to have been mistakenly/maybe purposely, flipped, always causing the unfavourable +5 attack option to be chosen
+            if (choice == 1)
             {
                 p.minionGetBuffed(own, 5, 0);
             }
-            if (choice == 1)
+            if (choice == 2)
             {
                 p.minionGetBuffed(own, 0, 5);
                 own.taunt = true;


### PR DESCRIPTION
Fixed the choices for "Ancient of War" to correspond to the correct actions, making the taunt choice likelier, which is more favourable in most cases, when playing a control deck.