### PR TITLE
RandomGenerators are expensive

### DIFF
--- a/ai/Playfield.cs
+++ b/ai/Playfield.cs
@@ -42,7 +42,8 @@
         public bool complete = false;
 
         public bool isServer = false;
-        public Random randomGenerator = new Random();
+        public static Random randomGeneratorInstance = new Random();
+        public Random randomGenerator = null;  // local reference to prevent changing all code locations
 
         //dont have to be copied! (server doesnt copy)
         public List<Handmanager.Handcard> myDeck ;
@@ -269,6 +270,7 @@
         public Playfield()
         {
             this.nextEntity = 1000;
+            this.randomGenerator = randomGeneratorInstance;
             //this.simulateEnemyTurn = Ai.Instance.simulateEnemyTurn;
             this.ownController = Hrtprozis.Instance.getOwnController();
 
@@ -625,6 +627,7 @@
         public Playfield(Playfield p)
         {
             this.isServer = p.isServer;
+            this.randomGenerator = randomGeneratorInstance;
             this.nextEntity = p.nextEntity;
 
             this.isOwnTurn = p.isOwnTurn;


### PR DESCRIPTION
Hit a System.OutOfMemoryException where the random generator is constructed. Decided to profile it a bit and see what was going on.

Turns out Random Generators are expensive objects to construct in general, but since every Playfield creates its own (and there's a lot of those), the simulations are spending about 10% of their time on that 1 line. Switched to a single static instance and verified my 10% speedup on large simulations.

See http://pastebin.com/tcwLgPiS for an example long-running test.txt (~30secs) that can help show the difference.